### PR TITLE
Enable scrolling when displayed scripts exceeds page height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/config.json
+++ b/config.json
@@ -1,18 +1,18 @@
 {
   "name": "ScriptTask",
   "shortName": "scripttask",
-  "version": "0.0.18p",
+  "version": "0.0.18",
   "author": "Ryan Blenis",
-  "description": "Script (PowerShell, BAT, Bash) runner for endpoints, updated by crettien",
+  "description": "Script (PowerShell, BAT, Bash) runner for endpoints",
   "hasAdminPanel": false,
-  "homepage": "https://github.com/crettien/MeshCentral-ScriptTask",
-  "changelogUrl": "https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/changelog.md",
-  "configUrl": "https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/config.json",
-  "downloadUrl": "https://github.com/crettien/MeshCentral-ScriptTask/archive/master.zip",
+  "homepage": "https://github.com/ryanblenis/MeshCentral-ScriptTask",
+  "changelogUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/changelog.md",
+  "configUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json",
+  "downloadUrl": "https://github.com/ryanblenis/MeshCentral-ScriptTask/archive/master.zip",
   "repository": {
     "type": "git",
-    "url": "https://github.com/crettien/MeshCentral-ScriptTask.git"
+    "url": "https://github.com/ryanblenis/MeshCentral-ScriptTask.git"
   },
-  "versionHistoryUrl": "https://api.github.com/repos/crettien/MeshCentral-ScriptTask/tags",
+  "versionHistoryUrl": "https://api.github.com/repos/ryanblenis/MeshCentral-ScriptTask/tags",
   "meshCentralCompat": ">=0.9.98"
 }

--- a/config.json
+++ b/config.json
@@ -1,18 +1,18 @@
 {
   "name": "ScriptTask",
   "shortName": "scripttask",
-  "version": "0.0.18",
+  "version": "0.0.18p",
   "author": "Ryan Blenis",
-  "description": "Script (PowerShell, BAT, Bash) runner for endpoints",
+  "description": "Script (PowerShell, BAT, Bash) runner for endpoints, updated by crettien",
   "hasAdminPanel": false,
-  "homepage": "https://github.com/ryanblenis/MeshCentral-ScriptTask",
-  "changelogUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/changelog.md",
-  "configUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json",
-  "downloadUrl": "https://github.com/ryanblenis/MeshCentral-ScriptTask/archive/master.zip",
+  "homepage": "https://github.com/crettien/MeshCentral-ScriptTask",
+  "changelogUrl": "https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/changelog.md",
+  "configUrl": "https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/config.json",
+  "downloadUrl": "https://github.com/crettien/MeshCentral-ScriptTask/archive/master.zip",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ryanblenis/MeshCentral-ScriptTask.git"
+    "url": "https://github.com/crettien/MeshCentral-ScriptTask.git"
   },
-  "versionHistoryUrl": "https://api.github.com/repos/ryanblenis/MeshCentral-ScriptTask/tags",
+  "versionHistoryUrl": "https://api.github.com/repos/crettien/MeshCentral-ScriptTask/tags",
   "meshCentralCompat": ">=0.9.98"
 }

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ A script running plugin for the [MeshCentral2](https://github.com/Ylianst/MeshCe
 >     },
 Restart your MeshCentral server after making this change.
 
- To install, simply add the plugin configuration URL when prompted:
- `https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json`
+ To install this version of the plugin, simply add the plugin configuration URL when prompted:
+ `https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/config.json`
 
 ## Features
 - Add scripts to a central store

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ A script running plugin for the [MeshCentral2](https://github.com/Ylianst/MeshCe
 Restart your MeshCentral server after making this change.
 
  To install this version of the plugin, simply add the plugin configuration URL when prompted:
- `https://raw.githubusercontent.com/crettien/MeshCentral-ScriptTask/master/config.json`
+ `https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json`
 
 ## Features
 - Add scripts to a central store

--- a/scripttask.js
+++ b/scripttask.js
@@ -45,15 +45,15 @@ module.exports.scripttask = function (parent) {
             tabTitle: 'ScriptTask',
             tabId: 'pluginScriptTask'
         });
-        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 800px;" scrolling="no" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
+        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px; overflow: scroll" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
     };
     // may not be needed, saving for later. Can be called to resize iFrame
     obj.resizeContent = function() {
         var iFrame = document.getElementById('pluginIframeScriptTask');
-        var newHeight = 800;
-        var sHeight = iFrame.contentWindow.document.body.scrollHeight;
-        if (sHeight > newHeight) newHeight = sHeight;
-        if (newHeight > 1600) newHeight = 1600;
+        var newHeight = 700;
+        // var sHeight = iFrame.contentWindow.document.body.scrollHeight;
+        // if (sHeight > newHeight) newHeight = sHeight;
+        // if (newHeight > 1600) newHeight = 1600;
         iFrame.style.height = newHeight + 'px';
     };
     


### PR DESCRIPTION
When the number of items in the Shared tree view exceeds page height, the page is not scrollable and newly created scripts cannot be selected. In the example below, scripts after "D" in folder Folder01 cannot be selected: 
<img width="1637" alt="Non scrollable page" src="https://user-images.githubusercontent.com/6123475/161057948-f3cbfe43-a953-470d-a234-d92a9523d539.png">
The suggested update changes the iframe style and resizeContent function as follows:
```
obj.onDeviceRefreshEnd = function() {
        pluginHandler.registerPluginTab({
            tabTitle: 'ScriptTask',
            tabId: 'pluginScriptTask'
        });
        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px; overflow: scroll" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
    };
    // may not be needed, saving for later. Can be called to resize iFrame
    obj.resizeContent = function() {
        var iFrame = document.getElementById('pluginIframeScriptTask');
        var newHeight = 700;
        // var sHeight = iFrame.contentWindow.document.body.scrollHeight;
        // if (sHeight > newHeight) newHeight = sHeight;
        // if (newHeight > 1600) newHeight = 1600;
        iFrame.style.height = newHeight + 'px';
    };
```

The above code sets the iframe style height to 700px and displays a Y-scrollbar when necessary.