### PR TITLE
fix error ExecutionPolicy, add args to powershell

### DIFF
--- a/modules_meshcore/scripttask.js
+++ b/modules_meshcore/scripttask.js
@@ -156,7 +156,7 @@ function runPowerShell(sObj, jObj) {
     try {
         fs.writeFileSync(pName, sObj.content);
         var outstr = '', errstr = '';
-        var child = require('child_process').execFile(process.env['windir'] + '\\system32\\WindowsPowerShell\\v1.0\\powershell.exe', ['-NoLogo'] );
+        var child = require('child_process').execFile(process.env['windir'] + '\\system32\\WindowsPowerShell\\v1.0\\powershell.exe', ['-NoLogo', '-NoProfile', '-ExecutionPolicy Bypass'] );
         child.stderr.on('data', function (chunk) { errstr += chunk; });
         child.stdout.on('data', function (chunk) { });
         runningJobPIDs[jObj.jobId] = child.pid;


### PR DESCRIPTION
When you run the powershell script, the ExecutionPolicy error comes out. This can be fixed either by changing the script execution policy on the host, or by running the script with "-ExecutionPolicy Bypass"