### PR TITLE
allow scrolling in the scriptcontainer to allow more scripts addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/config.json
+++ b/config.json
@@ -1,17 +1,17 @@
 {
   "name": "ScriptTask",
   "shortName": "scripttask",
-  "version": "0.0.18",
+  "version": "0.0.18b",
   "author": "Ryan Blenis",
-  "description": "Script (PowerShell, BAT, Bash) runner for endpoints",
+  "description": "Script (PowerShell, BAT, Bash) runner for endpoints. Modified beta version by smartekIT",
   "hasAdminPanel": false,
-  "homepage": "https://github.com/ryanblenis/MeshCentral-ScriptTask",
-  "changelogUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/changelog.md",
-  "configUrl": "https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json",
-  "downloadUrl": "https://github.com/ryanblenis/MeshCentral-ScriptTask/archive/master.zip",
+  "homepage": "https://github.com/smartekIT/MeshCentral-ScriptTask",
+  "changelogUrl": "https://raw.githubusercontent.com/smartekIT/MeshCentral-ScriptTask/master/changelog.md",
+  "configUrl": "https://raw.githubusercontent.com/smartekIT/MeshCentral-ScriptTask/master/config.json",
+  "downloadUrl": "https://github.com/smartekIT/MeshCentral-ScriptTask/archive/master.zip",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ryanblenis/MeshCentral-ScriptTask.git"
+    "url": "https://github.com/smartekIT/MeshCentral-ScriptTask.git"
   },
   "versionHistoryUrl": "https://api.github.com/repos/ryanblenis/MeshCentral-ScriptTask/tags",
   "meshCentralCompat": ">=0.9.98"

--- a/modules_meshcore/scripttask.js
+++ b/modules_meshcore/scripttask.js
@@ -156,7 +156,7 @@ function runPowerShell(sObj, jObj) {
     try {
         fs.writeFileSync(pName, sObj.content);
         var outstr = '', errstr = '';
-        var child = require('child_process').execFile(process.env['windir'] + '\\system32\\WindowsPowerShell\\v1.0\\powershell.exe', ['-NoLogo'] );
+        var child = require('child_process').execFile(process.env['windir'] + '\\system32\\WindowsPowerShell\\v1.0\\powershell.exe', ['-NoLogo', '-NoProfile', '-ExecutionPolicy Bypass'] );
         child.stderr.on('data', function (chunk) { errstr += chunk; });
         child.stdout.on('data', function (chunk) { });
         runningJobPIDs[jObj.jobId] = child.pid;

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ A script running plugin for the [MeshCentral2](https://github.com/Ylianst/MeshCe
 >     },
 Restart your MeshCentral server after making this change.
 
- To install, simply add the plugin configuration URL when prompted:
- `https://raw.githubusercontent.com/ryanblenis/MeshCentral-ScriptTask/master/config.json`
+ To install this modified version of plugin, simply add the plugin configuration URL when prompted:
+ `https://raw.githubusercontent.com/smartekIT/MeshCentral-ScriptTask/master/config.json`
 
 ## Features
 - Add scripts to a central store

--- a/scripttask.js
+++ b/scripttask.js
@@ -45,15 +45,15 @@ module.exports.scripttask = function (parent) {
             tabTitle: 'ScriptTask',
             tabId: 'pluginScriptTask'
         });
-        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 800px;" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
+        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px;" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
     };
     // may not be needed, saving for later. Can be called to resize iFrame
     obj.resizeContent = function() {
         var iFrame = document.getElementById('pluginIframeScriptTask');
-        var newHeight = 800;
-        var sHeight = iFrame.contentWindow.document.body.scrollHeight;
-        if (sHeight > newHeight) newHeight = sHeight;
-        if (newHeight > 1600) newHeight = 1600;
+        var newHeight = 700;
+        //var sHeight = iFrame.contentWindow.document.body.scrollHeight;
+        //if (sHeight > newHeight) newHeight = sHeight;
+        //if (newHeight > 1600) newHeight = 1600;
         iFrame.style.height = newHeight + 'px';
     };
     

--- a/scripttask.js
+++ b/scripttask.js
@@ -45,7 +45,7 @@ module.exports.scripttask = function (parent) {
             tabTitle: 'ScriptTask',
             tabId: 'pluginScriptTask'
         });
-        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px; overflow: scroll" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
+        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px; overflow: auto" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
     };
     // may not be needed, saving for later. Can be called to resize iFrame
     obj.resizeContent = function() {

--- a/scripttask.js
+++ b/scripttask.js
@@ -45,7 +45,7 @@ module.exports.scripttask = function (parent) {
             tabTitle: 'ScriptTask',
             tabId: 'pluginScriptTask'
         });
-        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 800px;" scrolling="no" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
+        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 800px;" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
     };
     // may not be needed, saving for later. Can be called to resize iFrame
     obj.resizeContent = function() {

--- a/scripttask.js
+++ b/scripttask.js
@@ -45,7 +45,7 @@ module.exports.scripttask = function (parent) {
             tabTitle: 'ScriptTask',
             tabId: 'pluginScriptTask'
         });
-        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px;" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
+        QA('pluginScriptTask', '<iframe id="pluginIframeScriptTask" style="width: 100%; height: 700px; overflow: scroll" scrolling="yes" frameBorder=0 src="/pluginadmin.ashx?pin=scripttask&user=1" />');
     };
     // may not be needed, saving for later. Can be called to resize iFrame
     obj.resizeContent = function() {

--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -457,7 +457,7 @@ function redrawScriptTree() {
   var str = '';
   var indent = 0;
   var folder_id = null;
-  str = '<div style="display: block;overflow-y: scroll;max-height: 650px;">'
+  str = '<div style="display: block;overflow-y: auto;max-height: 700px;">'
   scriptTree.forEach(function(f) {
     if (f.path != lastpath && f.type == 'folder') {
       indent = (f.path.match(/\//g) || []).length + 1;

--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -457,6 +457,7 @@ function redrawScriptTree() {
   var str = '';
   var indent = 0;
   var folder_id = null;
+  str = '<div style="display: block;overflow-y: scroll;max-height: 650px;">'
   scriptTree.forEach(function(f) {
     if (f.path != lastpath && f.type == 'folder') {
       indent = (f.path.match(/\//g) || []).length + 1;


### PR DESCRIPTION
This will separate the scriptcontainer area section with it's own nice scrolling bar. it allow the addition of endless scripts and provide better view and control over the scripts. 

![Screenshot 2023-05-14 131207](https://github.com/ryanblenis/MeshCentral-ScriptTask/assets/70715469/c7c95c31-2bae-4c54-bff9-d42c6dc3541e)
