### PR TITLE
utilizing mongodb TTL feature 

### DIFF
--- a/db.js
+++ b/db.js
@@ -196,7 +196,8 @@ module.exports.CreateDB = function(meshserver) {
         };
         obj.deleteOldHistory = function() {
             var nowTime = Math.floor(new Date() / 1000);
-            var oldTime = nowTime - (86400 * 90); // 90 days
+            //var oldTime = nowTime - (86400 * 90); // 90 days
+            var oldTime = nowTime - (86400 * 30); // 30 days
             return obj.scriptFile.deleteMany( { type: 'job', completeTime: { $lte: oldTime } } );
         };
         obj.addVariable = function(name, scope, scopeTarget, value) {
@@ -263,7 +264,7 @@ module.exports.CreateDB = function(meshserver) {
               // Check if we need to reset indexes
               var indexesByName = {}, indexCount = 0;
               for (var i in indexes) { indexesByName[indexes[i].name] = indexes[i]; indexCount++; }
-              if ((indexCount != 6) || (indexesByName['ScriptName1'] == null) || (indexesByName['ScriptPath1'] == null) || (indexesByName['JobTime1'] == null) || (indexesByName['JobNode1'] == null) || (indexesByName['JobScriptID1'] == null)) {
+              if ((indexCount != 7) || (indexesByName['ScriptName1'] == null) || (indexesByName['ScriptPath1'] == null) || (indexesByName['JobTime1'] == null) || (indexesByName['JobNode1'] == null) || (indexesByName['JobScriptID1'] == null)) || (indexesByName['ClearScriptHist'] == null)) {
                   // Reset all indexes
                   console.log('Resetting plugin (ScriptTask) indexes...');
                   obj.scriptFile.dropIndexes(function (err) {
@@ -272,6 +273,7 @@ module.exports.CreateDB = function(meshserver) {
                       obj.scriptFile.createIndex({ queueTime: 1 }, { name: 'JobTime1' });
                       obj.scriptFile.createIndex({ node: 1 }, { name: 'JobNode1' });
                       obj.scriptFile.createIndex({ scriptId: 1 }, { name: 'JobScriptID1' });
+                      obj.scriptFile.createIndex({ completeTime: 1 }, {name: 'ClearScriptHist', partialFilterExpression: { returnVal: { '$exists': true }, type: { '$eq': 'job' } }, expireAfterSeconds: 604800});
                   }); 
               }
           });
@@ -294,6 +296,7 @@ module.exports.CreateDB = function(meshserver) {
             obj.scriptFilex.ensureIndex({ fieldName: 'queueTime' });
             obj.scriptFilex.ensureIndex({ fieldName: 'node' });
             obj.scriptFilex.ensureIndex({ fieldName: 'scriptId' });
+            obj.scriptFilex.ensureIndex({ fieldName: 'completeTime' });
         }
         obj.scriptFile = new NEMongo(obj.scriptFilex);
         formatId = function(id) { return id; };

--- a/db.js
+++ b/db.js
@@ -273,7 +273,7 @@ module.exports.CreateDB = function(meshserver) {
                       obj.scriptFile.createIndex({ queueTime: 1 }, { name: 'JobTime1' });
                       obj.scriptFile.createIndex({ node: 1 }, { name: 'JobNode1' });
                       obj.scriptFile.createIndex({ scriptId: 1 }, { name: 'JobScriptID1' });
-                      obj.scriptFile.createIndex({ completeTime: 1 }, {name: 'ClearScriptHist', partialFilterExpression: { returnVal: { '$exists': true }, type: { '$eq': 'job' } }, expireAfterSeconds: 604800});
+                      obj.scriptFile.createIndex({ completeTime: 1 }, {name: 'ClearScriptHist', partialFilterExpression: { returnVal: { '$exists': true }, type: { '$eq': 'job' } }, expireAfterSeconds: 2592000});
                   }); 
               }
           });

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,8 @@ Restart your MeshCentral server after making this change.
 - Queues are checked / run every minute.
 - Scheduled jobs only show the *next* scheduled job at any given time.
 - History is limited to 200 events per node/script in the viewport.
-- Historical events that have completed will delete after 90 days.
+- Historical events that have completed will delete after 30 days.
+- For mongodb it's even faster cleaning by using the TTL feature to delete completed jobs after 30 days.
 - Jobs only run when the endpoint agent is online. They do *not* queue to the agent when offline, then run at the specified time.
 - Scripts are cached on the clients and verified via hash at runtime for the latest version.
 

--- a/scripttask.js
+++ b/scripttask.js
@@ -656,7 +656,8 @@ module.exports.scripttask = function (parent) {
                 //obj.debug('ScriptTask', 'jobComplete Triggered', JSON.stringify(command));
                 var jobNodeHistory = null, scriptHistory = null;
                 var jobId = command.jobId, retVal = command.retVal, errVal = command.errVal, dispatchTime = command.dispatchTime;
-                var completeTime = Math.floor(new Date() / 1000);
+                //var completeTime = Math.floor(new Date() / 1000);
+                var completeTime = (new Date());
                 obj.db.update(jobId, {
                     completeTime: completeTime,
                     returnVal: retVal,
@@ -670,7 +671,8 @@ module.exports.scripttask = function (parent) {
                     })
                     .then(sId => {
                         if (sId == null) return Promise.resolve();
-                        return obj.db.update(sId, { lastRun: completeTime } )
+                        //return obj.db.update(sId, { lastRun: completeTime } )
+                        return obj.db.update(sId, { lastRun: dispatchTime } )
                         .then(() => {
                             obj.makeJobsFromSchedules(sId);
                         });

--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -511,7 +511,8 @@ function redrawScriptTree() {
           }
           if (message.event.nodeHistory.length) {
               message.event.nodeHistory.forEach(function(nh) {
-                 nh.latestTime = Math.max(nh.completeTime, nh.queueTime, nh.dispatchTime, nh.dontQueueUntil); 
+                 //nh.latestTime = Math.max(nh.completeTime, nh.queueTime, nh.dispatchTime, nh.dontQueueUntil); 
+                 nh.latestTime = Math.max(nh.queueTime, nh.dispatchTime, nh.dontQueueUntil);
               });
               message.event.nodeHistory.sort((a, b) => (a.latestTime < b.latestTime) ? 1 : -1);
               message.event.nodeHistory.forEach(function(nh) {
@@ -539,7 +540,8 @@ function redrawScriptTree() {
           }
           if (message.event.scriptHistory.length) {
               message.event.scriptHistory.forEach(function(nh) {
-                 nh.latestTime = Math.max(nh.completeTime, nh.queueTime, nh.dispatchTime, nh.dontQueueUntil); 
+                 //nh.latestTime = Math.max(nh.completeTime, nh.queueTime, nh.dispatchTime, nh.dontQueueUntil); 
+                 nh.latestTime = Math.max(nh.queueTime, nh.dispatchTime, nh.dontQueueUntil);
               });
               message.event.scriptHistory.sort((a, b) => (a.latestTime < b.latestTime) ? 1 : -1);
               message.event.scriptHistory.forEach(function(nh) {


### PR DESCRIPTION
It's faster and easier to rely on mongodb TTL feature to clean the old finished jobs after 30 days.
This update is changing the format how we save the completeTime value in the database of ScriptTask.
Also it adds a new index to the database to activate the TTL feature to clean finished jobs older than 30 days. Because of this index addition it will cause re-indexing of the ScriptTask db when update (no data lose at all, but it's a good thing to backup database before updating).