### PR TITLE
Added CSV export of script history

### DIFF
--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -231,6 +231,7 @@
         </div>
         <div class="infoBar">Script History</div>
         <div id="scriptHistory" class="infoContent">
+            <span class="flink" onclick="exportScriptHistory();return false;">[Export]</span>
             <table id="sHistTbl" cellspacing="0" cellpadding="0">
                 <th>Time</th><th>Run By</th><th>Node</th><th>Status</th><th>Return Value</th>
             </table>
@@ -1018,5 +1019,13 @@ function redrawScriptTree() {
   });
   dropZone.addEventListener('drop', handleFileSelect);
   
+  function exportScriptHistory() {
+    var isSelected = document.querySelectorAll('.liselected');
+    if (isSelected.length == 0) return;
+    var sel = isSelected[0];
+    var id = sel.getAttribute('x-data-id');
+    if (id == sel.getAttribute('x-data-folder')) return;
+    window.location = '/pluginadmin.ashx?pin=scripttask&export=1&dl='+id;
+  }
 </script>
 </html>


### PR DESCRIPTION
Hello,

I'd like to propose my addition to your plugin, which allows you to export script history in CSV format.

Here you can see the history of one of my scripts and the export button:
![image](https://github.com/user-attachments/assets/610931bf-2a50-4d9b-860e-7e068830f5b8)

And when you click on the export button, a CSV file like this one is generated:
![image](https://github.com/user-attachments/assets/0e7ad956-6043-4618-a3c2-f0617edc3fc6)

Best regards,
Lucas AVELINO



