### PR TITLE
Expose runBy as global replacement variable

### DIFF
--- a/scripttask.js
+++ b/scripttask.js
@@ -94,6 +94,7 @@ module.exports.scripttask = function (parent) {
                         });
                         replaceVars['GBL:meshId'] = obj.meshServer.webserver.wsagents[job.node]['dbMeshKey'];
                         replaceVars['GBL:nodeId'] = job.node;
+                        replaceVars['GBL:runBy'] = job.runBy || 'unknown';
                         //console.log('FV IS', finvals);
                         //console.log('RV IS', replaceVars);
                     }


### PR DESCRIPTION
This exposes the existing job `runBy` value as a built-in global replacement variable:

`#GBL:runBy#`

ScriptTask already stores the user who manually triggered a job via `runBy`, and scheduled jobs inherit `scheduledBy` into `runBy` when the job is created.

This allows scripts to include the MeshCentral user in logs, audit output, email notifications, and other script-generated records.

The change is backwards-compatible and follows the existing pattern used for `GBL:meshId` and `GBL:nodeId`.